### PR TITLE
Update requirements

### DIFF
--- a/cs336-systems/requirements.txt
+++ b/cs336-systems/requirements.txt
@@ -1,6 +1,7 @@
 regex
 torch~=2.2.1
 numpy
+matplotlib
 humanfriendly
 # Includes a bugfix for recent NCCL versions
 HolisticTraceAnalysis @ git+https://github.com/nelson-liu/HolisticTraceAnalysis.git@comm_kernel_fix


### PR DESCRIPTION
matplotlib is required by memory profiler

> export_memory_timeline_html failed because matplotlib was not found.