### PR TITLE
Fix weight tying test

### DIFF
--- a/cs336-systems/tests/common.py
+++ b/cs336-systems/tests/common.py
@@ -59,6 +59,7 @@ class ToyModelWithTiedWeights(nn.Module):
         self.fc3 = nn.Linear(50, 10, bias=False)
         self.fc4 = nn.Linear(10, 50, bias=False)
         self.fc5 = nn.Linear(50, 5, bias=False)
+        self.fc4.weight = self.fc2.weight
         self.relu = nn.ReLU()
 
     def forward(self, x):


### PR DESCRIPTION
This ToyModelWithTiedWeights model doesn't really have any tied weights. I assume you want to tie fc2 with fc4?